### PR TITLE
Add marital status and spouse income

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from policyengine_us import Simulation
 import streamlit as st
+import numpy as np
 
 # This is an app which tells people how much money they'd need to donate to lower their net income (after taxes and benefits) by x%.
 
@@ -12,7 +13,13 @@ st.write("This tool will tell you how much you should donate to charity to lower
 
 # Now, we ask the user for their income and the amount they want to lower it by.
 
-income = st.number_input("What is your annual income?", min_value=0, max_value=1000000, value=50000, step=1000)
+income_params = dict(min_value=0, max_value=1000000, step=1000)
+user_income = st.number_input("What is your annual income?", **income_params, value=50000)
+
+marital_status = st.selectbox("Marital status", ["single", "married"])
+
+if marital_status == 'married':
+    spouse_income = st.number_input("What is your spouse's annual income?", **income_params, value=0)
 
 # Give people the option of inputting a percent or absolute amount to lower their net income by.
 
@@ -20,21 +27,27 @@ lower_by = st.selectbox("Lower my net income by", ["a percentage", "an absolute 
 
 if lower_by == "a percentage":
     lower_by_amount = st.number_input("Lower my net income by what percentage?", min_value=0, max_value=100, value=10, step=1)
-    lower_by_amount = income * lower_by_amount / 100
+    lower_by_amount = user_income * lower_by_amount / 100
 else:
     lower_by_amount = st.number_input("Lower my net income by what amount?", min_value=0, max_value=1000000, value=10000, step=1000)
 
+
+people = dict(
+    person=dict(employment_income={2022: user_income})
+)
+people_names = ["person"]
+
+if marital_status == 'married':
+    people['spouse'] = dict(employment_income={2022: spouse_income})
+    people_names.append("spouse")
+
 simulation = Simulation(
     situation=dict(
-        people=dict(
-            person=dict(
-                employment_income={2022: income},
-            ),
-        ),
+        people=people,
         tax_units=dict(
             tax_unit=dict(
                 premium_tax_credit={2022: 0},
-                members=["person"],
+                members=people_names,
             )
         ),
         axes=[[
@@ -49,7 +62,7 @@ simulation = Simulation(
 )
 
 net_income_by_donation = simulation.calculate("household_net_income")
-donations = simulation.calculate("charitable_cash_donations")
+donations = np.reshape(simulation.calculate("charitable_cash_donations"), (len(people_names), 101))[0]
 
 import plotly.express as px
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 policyengine-us
 plotly
+numpy


### PR DESCRIPTION
This adds a selectbox to choose marital status which, if marital status is set to "married", causes an additional text box to be shown to enter your spouse's income.