### PR TITLE
Move calculate button to sticky position within left panel

### DIFF
--- a/frontend/.vite/deps/_metadata.json
+++ b/frontend/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "2c813f6f",
+  "configHash": "7f3eeb35",
+  "lockfileHash": "1982d69a",
+  "browserHash": "48a694fe",
+  "optimized": {},
+  "chunks": {}
+}

--- a/frontend/.vite/deps/package.json
+++ b/frontend/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -203,6 +203,20 @@ function Calculator() {
               states={states}
             />
             <TaxInfo stateCode={formState.state_code} />
+            {/* Sticky Calculate Button - attached to left panel */}
+            <div className="sticky bottom-4">
+              <button
+                onClick={handleCalculate}
+                disabled={isCalculating}
+                className={`w-full py-3 px-4 rounded-md font-semibold text-white transition-colors shadow-lg ${
+                  isCalculating
+                    ? "bg-gray-400 cursor-not-allowed"
+                    : "bg-primary-500 hover:bg-primary-600"
+                }`}
+              >
+                {isCalculating ? "Calculating..." : "Calculate tax impact"}
+              </button>
+            </div>
           </div>
 
           {/* Right Column - Results */}
@@ -226,25 +240,8 @@ function Calculator() {
         </div>
       </main>
 
-      {/* Sticky Calculate Button */}
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 shadow-lg z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <button
-            onClick={handleCalculate}
-            disabled={isCalculating}
-            className={`w-full py-3 px-4 rounded-md font-semibold text-white transition-colors ${
-              isCalculating
-                ? "bg-gray-400 cursor-not-allowed"
-                : "bg-primary-500 hover:bg-primary-600"
-            }`}
-          >
-            {isCalculating ? "Calculating..." : "Calculate tax impact"}
-          </button>
-        </div>
-      </div>
-
       {/* Footer */}
-      <footer className="border-t border-gray-200 mt-12 pb-20">
+      <footer className="border-t border-gray-200 mt-12">
         <div className="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
             <div className="flex flex-col sm:flex-row items-center gap-4">

--- a/frontend/src/components/TaxChart.tsx
+++ b/frontend/src/components/TaxChart.tsx
@@ -62,6 +62,7 @@ export default function TaxChart({ curve, currentDonation }: Props) {
           title: { text: "Net taxes" },
           tickformat: "$,.0f",
           gridcolor: "#E2E8F0",
+          rangemode: "tozero",
         },
         plot_bgcolor: "white",
         paper_bgcolor: "white",


### PR DESCRIPTION
## Summary
- Move calculate button from full-width fixed footer to sticky position within left input panel
- Button now stays visible at bottom of input panel as you scroll

## Test plan
- [ ] Verify button sticks to bottom of left panel when scrolling
- [ ] Verify button works correctly on mobile
- [ ] Test calculation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)