### PR TITLE
Hardcode states list for instant UI load

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,16 +21,66 @@ const api = axios.create({
   },
 });
 
+// Hardcoded states list for instant UI load (avoids Cloud Run cold start)
+const STATES: StatesResponse = {
+  states: [
+    { code: "AL", name: "Alabama" },
+    { code: "AK", name: "Alaska" },
+    { code: "AZ", name: "Arizona" },
+    { code: "AR", name: "Arkansas" },
+    { code: "CA", name: "California" },
+    { code: "CO", name: "Colorado" },
+    { code: "CT", name: "Connecticut" },
+    { code: "DE", name: "Delaware" },
+    { code: "FL", name: "Florida" },
+    { code: "GA", name: "Georgia" },
+    { code: "HI", name: "Hawaii" },
+    { code: "ID", name: "Idaho" },
+    { code: "IL", name: "Illinois" },
+    { code: "IN", name: "Indiana" },
+    { code: "IA", name: "Iowa" },
+    { code: "KS", name: "Kansas" },
+    { code: "KY", name: "Kentucky" },
+    { code: "LA", name: "Louisiana" },
+    { code: "ME", name: "Maine" },
+    { code: "MD", name: "Maryland" },
+    { code: "MA", name: "Massachusetts" },
+    { code: "MI", name: "Michigan" },
+    { code: "MN", name: "Minnesota" },
+    { code: "MS", name: "Mississippi" },
+    { code: "MO", name: "Missouri" },
+    { code: "MT", name: "Montana" },
+    { code: "NE", name: "Nebraska" },
+    { code: "NV", name: "Nevada" },
+    { code: "NH", name: "New Hampshire" },
+    { code: "NJ", name: "New Jersey" },
+    { code: "NM", name: "New Mexico" },
+    { code: "NY", name: "New York" },
+    { code: "NC", name: "North Carolina" },
+    { code: "ND", name: "North Dakota" },
+    { code: "OH", name: "Ohio" },
+    { code: "OK", name: "Oklahoma" },
+    { code: "OR", name: "Oregon" },
+    { code: "PA", name: "Pennsylvania" },
+    { code: "RI", name: "Rhode Island" },
+    { code: "SC", name: "South Carolina" },
+    { code: "SD", name: "South Dakota" },
+    { code: "TN", name: "Tennessee" },
+    { code: "TX", name: "Texas" },
+    { code: "UT", name: "Utah" },
+    { code: "VT", name: "Vermont" },
+    { code: "VA", name: "Virginia" },
+    { code: "WA", name: "Washington" },
+    { code: "WV", name: "West Virginia" },
+    { code: "WI", name: "Wisconsin" },
+    { code: "WY", name: "Wyoming" },
+    { code: "DC", name: "District of Columbia" },
+  ],
+};
+
 export async function getStates(): Promise<StatesResponse> {
-  console.log("Fetching states from:", API_URL + "/api/states");
-  try {
-    const response = await api.get<StatesResponse>("/api/states");
-    console.log("States response:", response.data);
-    return response.data;
-  } catch (error) {
-    console.error("Failed to fetch states:", error);
-    throw error;
-  }
+  // Return hardcoded states instantly - no API call needed
+  return STATES;
 }
 
 export async function getTaxPrograms(


### PR DESCRIPTION
## Summary
- Hardcodes the US states list in the frontend to avoid Cloud Run cold start delay
- States list is static and doesn't change, so no reason to fetch from API
- UI will now load instantly while only calculations trigger the backend

## Test plan
- [ ] Visit givecalc.org and verify states dropdown loads immediately
- [ ] Verify all 50 states + DC are present in dropdown
- [ ] Verify calculations still work after selecting a state

🤖 Generated with [Claude Code](https://claude.com/claude-code)