### PR TITLE
Add PolicyEngine header

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
+import PolicyEngineHeader from '@/components/PolicyEngineHeader';
 
 const TITLE = 'GiveCalc - Charitable Donation Tax Calculator';
 const DESCRIPTION =
@@ -27,7 +28,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <PolicyEngineHeader />
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/src/components/PolicyEngineHeader.tsx
+++ b/frontend/src/components/PolicyEngineHeader.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Header } from "@policyengine/ui-kit";
+
+const navItems = [
+  { label: "Research", href: "https://policyengine.org/us/research" },
+  { label: "Model", href: "https://policyengine.org/us/model" },
+  { label: "API", href: "https://policyengine.org/us/api" },
+  {
+    label: "About",
+    href: "https://policyengine.org/us/team",
+    children: [
+      { label: "Team", href: "https://policyengine.org/us/team" },
+      { label: "Supporters", href: "https://policyengine.org/us/supporters" },
+    ],
+  },
+  { label: "Donate", href: "https://policyengine.org/us/donate" },
+];
+
+const countries = [
+  { id: "us", label: "United States" },
+  { id: "uk", label: "United Kingdom" },
+];
+
+export default function PolicyEngineHeader() {
+  return (
+    <Header
+      navItems={navItems}
+      countries={countries}
+      currentCountry="us"
+      logoHref="https://policyengine.org/us"
+      onCountryChange={(countryId) => {
+        window.location.href = `https://policyengine.org/${countryId}`;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary\n- render the shared ui-kit PolicyEngine header above GiveCalc\n- keep existing app content and /us/givecalc base path unchanged\n\n## Tests\n- bun run lint (existing warning only)\n- bun run test\n- bun run build