### PR TITLE
Fix GiveCalc routing and API CORS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ df["marginal_savings"] = -np.gradient(df.income_tax_after_donations) / \
 
 ## Common gotchas
 
-1. **API URL**: Set `VITE_API_URL` in `frontend/.env` (defaults to `http://localhost:8000`)
+1. **API URL**: Set `NEXT_PUBLIC_API_URL` in `frontend/.env` (defaults to `http://localhost:8000`)
 2. **Modal deploy**: Must `unset MODAL_TOKEN_ID MODAL_TOKEN_SECRET` before deploying to policyengine workspace
 3. **Vercel deploy**: Root `vercel.json` builds frontend/ -- deploy from repo root, not frontend/
 4. **NYC checkbox**: Only shown for NY state (handled in InputForm.tsx)
@@ -190,7 +190,7 @@ df["marginal_savings"] = -np.gradient(df.income_tax_after_donations) / \
 ```bash
 cd frontend && npm run dev   # Dev server with hot reload
 # Check browser console for API errors
-# VITE_API_URL in .env controls backend URL
+# NEXT_PUBLIC_API_URL in .env controls backend URL
 ```
 
 ### Backend

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ gcloud run deploy givecalc \
 ### Environment Variables
 
 **Frontend (build-time):**
-- `VITE_API_URL`: Backend API URL
+- `NEXT_PUBLIC_API_URL`: Backend API URL
 
 **Backend:**
 - `PORT`: Server port (default: 8080, set by Cloud Run)

--- a/api/main.py
+++ b/api/main.py
@@ -66,6 +66,8 @@ app.add_middleware(
         "http://localhost:5176",
         "https://givecalc.org",
         "https://www.givecalc.org",
+        "https://policyengine.org",
+        "https://www.policyengine.org",
     ],
     allow_credentials=True,
     allow_methods=["*"],

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,4 +3,4 @@
 # Copy this file to .env and fill in the values.
 
 # API URL - required for production builds, defaults to http://localhost:8000 for local dev
-VITE_API_URL=https://policyengine--givecalc-fastapi-app.modal.run
+NEXT_PUBLIC_API_URL=https://policyengine--givecalc-fastapi-app.modal.run

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,10 +4,32 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
   ? process.env.NEXT_PUBLIC_BASE_PATH
   : '/us/givecalc';
 
+const productionApiUrl = 'https://policyengine--givecalc-fastapi-app.modal.run';
+const apiUrl =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.VITE_API_URL ||
+  (process.env.VERCEL ? productionApiUrl : undefined);
 
 const nextConfig: NextConfig = {
   ...(basePath ? { basePath } : {}),
-  env: { NEXT_PUBLIC_BASE_PATH: basePath },
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+    ...(apiUrl ? { NEXT_PUBLIC_API_URL: apiUrl } : {}),
+  },
+  async redirects() {
+    if (!basePath) {
+      return [];
+    }
+
+    return [
+      {
+        source: '/',
+        destination: basePath,
+        basePath: false,
+        permanent: false,
+      },
+    ];
+  },
   // Pin the workspace root so Turbopack does not silently pick up a stray
   // lockfile from a parent directory during local development or CI.
   turbopack: {

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,34 @@
+"""Tests for API CORS configuration."""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("USE_MODAL", "false")
+
+from api.main import app
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://givecalc.org",
+        "https://www.givecalc.org",
+        "https://policyengine.org",
+        "https://www.policyengine.org",
+    ],
+)
+def test_production_frontend_origins_can_call_api(origin):
+    response = client.options(
+        "/api/calculate",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin


### PR DESCRIPTION
## Summary
- bake the Modal API URL into Vercel builds so the deployed frontend does not call localhost
- redirect the standalone root path to /us/givecalc to avoid the givecalc.org 404
- allow PolicyEngine origins in API CORS and add regression coverage
- update docs/env example for NEXT_PUBLIC_API_URL

Closes #80.

## Tests
- bun run lint
- uv run pytest tests/test_cors.py -v
- VERCEL=1 bun run build
- local production smoke test: / redirects to /us/givecalc, /us/givecalc returns 200